### PR TITLE
pygame compatibility changes (but should be applicable to everyone)

### DIFF
--- a/reloader.py
+++ b/reloader.py
@@ -39,16 +39,25 @@ __all__ = ('enable', 'disable', 'get_dependencies', 'reload')
 _baseimport = builtins.__import__
 _dependencies = dict()
 _parent = None
+_existing_modules = None
 
-def enable():
+def enable(ignore_existing_dependencies=False):
     """Enable global module dependency tracking."""
+    global _existing_modules
+    if ignore_existing_dependencies:
+      _existing_modules = list(sys.modules.values())
+    else:
+      _existing_modules = []
     builtins.__import__ = _import
 
 def disable():
     """Disable global module dependency tracking."""
     builtins.__import__ = _baseimport
     _dependencies.clear()
+    global _parent
     _parent = None
+    global _existing_modules
+    _existing_modules = None
 
 def get_dependencies(m):
     """Get the dependency list for the given imported module."""
@@ -133,14 +142,19 @@ def _import(name, globals=None, locals=None, fromlist=None, level=-1):
     # returns the top-level module reference for a nested import statement
     # (e.g. `import package.module`).
     base_returned_module = _baseimport(name, globals, locals, fromlist, level)
-    m = sys.modules.get(name, None)
+    
+    # Don't add this module as a dependency if it was imported before
+    # enable() was called. This allows the user an explicit way to
+    # prevent modules from being reloaded.
+    if not base_returned_module in _existing_modules:
+      m = sys.modules.get(name, None)
 
-    # If we have a parent (i.e. this is a nested import) and this is a
-    # reloadable (source-based) module, we append ourself to our parent's
-    # dependency list.
-    if parent is not None and hasattr(m, '__file__'):
-        l = _dependencies.setdefault(parent, [])
-        l.append(m)
+      # If we have a parent (i.e. this is a nested import) and this is a
+      # reloadable (source-based) module, we append ourself to our parent's
+      # dependency list.
+      if parent is not None and hasattr(m, '__file__'):
+          l = _dependencies.setdefault(parent, [])
+          l.append(m)
 
     # Lastly, we always restore our global _parent pointer.
     _parent = parent


### PR DESCRIPTION
Made a couple of changes to support the use of this with pygame.

The first fixes what I think is a bug, by returning the result of _baseimport rather than the module that we pull out of sys.modules. This helps fix a problem in the `__init__.py` for pygame.

The second deals with the fact that certain modules, such as pygame, cannot be reloaded (and crash if this is attempted). It adds a parameter to enable(), ignore_existing_dependencies. If this parameter is True, then any modules imported before enable() is called will be ignored for the purposes of dependency calculation. Thus you can do something like:

import pygame
import reloader
reloader.enable(ignore_existing_dependencies=True)
...

and you're safe.

The second change also adds a missing "global" to disable().
