### PR TITLE
support import of modules under packages missing attributes

### DIFF
--- a/reloader.py
+++ b/reloader.py
@@ -169,8 +169,7 @@ def _import(name, globals=None, locals=None, fromlist=None, level=_default_level
                 try:
                     m = getattr(m, component)
                 except AttributeError:
-                    component = ".".join([m.__name__, component])
-                    m = sys.modules[component]
+                    m = sys.modules[m.__name__ + '.' + component]
 
         # If this is a nested import for a reloadable (source-based) module,
         # we append ourself to our parent's dependency list.


### PR DESCRIPTION
In some cases a package is loaded that doesn't have all it's descendants
as attributes. When importing a descendant with `fromlist == None` then
an `AttributeError` is thrown in `_import`. This is the case for example
when importing `django.template.defaulttags`.

The proposed fix is to use `sys.modules` with the full name of the
immediate ancestor of the module, but only if the current method trows
an `AttributeError`.
