### PR TITLE
Fix collision with the builtins module from the future (that has no __import__ attribute

### DIFF
--- a/reloader.py
+++ b/reloader.py
@@ -22,10 +22,7 @@
 
 """Python Module Reloader"""
 
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
+import __builtin__ as system_builtins
 
 import copy
 import imp
@@ -37,7 +34,7 @@ __version__ = '0.7.dev0'
 
 __all__ = ('enable', 'disable', 'get_dependencies', 'reload')
 
-_baseimport = builtins.__import__
+_baseimport = system_builtins.__import__
 _blacklist = None
 _dependencies = dict()
 _parent = None
@@ -60,7 +57,7 @@ def enable(blacklist=None):
     will just not be reloaded.
     """
     global _blacklist
-    builtins.__import__ = _import
+    system_builtins.__import__ = _import
     if blacklist is not None:
         _blacklist = frozenset(blacklist)
 
@@ -68,7 +65,7 @@ def enable(blacklist=None):
 def disable():
     """Disable global module dependency tracking."""
     global _blacklist, _parent
-    builtins.__import__ = _baseimport
+    system_builtins.__import__ = _baseimport
     _blacklist = None
     _dependencies.clear()
     _parent = None


### PR DESCRIPTION
I encountered a bug: in newer versions of python 2.7.x (but not all of them, for instance, not in the Anaconda bundles) you have a builtins module that doesn't include the __import__ attribute.

I changed it to always look for the __builtins__ module.

What do you think?