### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ An Interactive Example
 ----------------------
 
 This example demonstrates how easily the reloader can be used from the
-interactive Python interpretter.  Imagine you have the module ``example.py``
+interactive Python interpreter.  Imagine you have the module ``example.py``
 open in a text editor, and it contains the following:
 
 .. code-block:: python

--- a/reloader.py
+++ b/reloader.py
@@ -56,7 +56,7 @@ def enable(blacklist=None):
     """Enable global module dependency tracking.
 
     A blacklist can be specified to exclude specific modules (and their import
-    hierachies) from the reloading process.  The blacklist can be any iterable
+    hierarchies) from the reloading process.  The blacklist can be any iterable
     listing the fully-qualified names of modules that should be ignored.  Note
     that blacklisted modules will still appear in the dependency graph; they
     will just not be reloaded.


### PR DESCRIPTION
There are small typos in:
- README.rst
- reloader.py

Fixes:
- Should read `interpreter` rather than `interpretter`.
- Should read `hierarchies` rather than `hierachies`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md